### PR TITLE
Add a printer dry run command `librocco-printer-test`:

### DIFF
--- a/librocco_receipt_printer/cli.py
+++ b/librocco_receipt_printer/cli.py
@@ -25,5 +25,22 @@ def main():
         print("Exiting")
 
 
+def dry_run():
+    """Dry run is used for `librocco-print-test` command. It prints a canned receipt
+    and is used to test the printer being connected and accessible.
+
+    TODO: This should most definitely be an actual printer, not a test file
+
+    TODO: When we proceed with the implementation (and formatting of receipts) we'd
+    probably want to store a dummy receipt and print it out (instead of just printing out the "Test receipt" string)
+    """
+
+    printer = DevPrinter(PRINT_OUTPUT_FILE)
+    printer.print("Test receipt\n")
+
+
 if __name__ == "__main__":
     main()
+
+if __name__ == "__dry_run__":
+    dry_run()

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     entry_points={
         "console_scripts": [
             "librocco-receipt-printer=librocco_receipt_printer.cli:main",
+            "librocco-print-test=librocco_receipt_printer.cli:dry_run",
         ],
     },
 )


### PR DESCRIPTION
* Prints out "Test receipt" string using `DevPrinter` (file)
* In the future it should print a canned receipt using the actual printer